### PR TITLE
gitian-building: bump Debian netinstall to 8.9 + OSX shasum command

### DIFF
--- a/gitian-building/gitian-building-create-vm-debian.md
+++ b/gitian-building/gitian-building-create-vm-debian.md
@@ -60,12 +60,14 @@ After creating the VM, we need to configure it.
 
 - Click `Ok` twice to save.
 
-Get the [Debian 8.x net installer](http://cdimage.debian.org/mirror/cdimage/archive/8.5.0/amd64/iso-cd/debian-8.5.0-amd64-netinst.iso) (a more recent minor version should also work, see also [Debian Network installation](https://www.debian.org/CD/netinst/)).
+Get the [Debian 8.x net installer](http://cdimage.debian.org/mirror/cdimage/archive/8.9.0/amd64/iso-cd/debian-8.9.0-amd64-netinst.iso) (a more recent minor version should also work, see also [Debian Network installation](https://www.debian.org/CD/netinst/)).
 This DVD image can be [validated](https://www.debian.org/CD/verify) using a SHA256 hashing tool, for example on
 Unixy OSes by entering the following in a terminal:
 
-    echo "ad4e8c27c561ad8248d5ebc1d36eb172f884057bfeb2c22ead823f59fa8c3dff  debian-8.5.0-amd64-netinst.iso" | sha256sum -c
+    echo "fd11d34f8abf1663a33cc10a9ed998160866ef94072d442159bcfa1438be70d4  debian-8.9.0-amd64-netinst.iso" | sha256sum -c
     # (must return OK)
+
+Replace `sha256sum` with `shasum` on OSX.
 
 Then start the VM. On the first launch you will be asked for a CD or DVD image. Choose the downloaded ISO.
 


### PR DESCRIPTION
I used version 8.9 to generate the asserts in bitcoin-core/gitian.sigs#603 & bitcoin-core/gitian.sigs#606.

OSX uses `shasum` instead of `shasum256` (trying to make this as easy as possible...).