### PR TITLE
Replace dead Debian netinst URL and bump to Debian 8.10.0

### DIFF
--- a/gitian-building/gitian-building-create-vm-debian.md
+++ b/gitian-building/gitian-building-create-vm-debian.md
@@ -60,11 +60,11 @@ After creating the VM, we need to configure it.
 
 - Click `Ok` twice to save.
 
-Get the [Debian 8.x net installer](http://cdimage.debian.org/mirror/cdimage/archive/8.9.0/amd64/iso-cd/debian-8.9.0-amd64-netinst.iso) (a more recent minor version should also work, see also [Debian Network installation](https://www.debian.org/CD/netinst/)).
+Get the [Debian 8.x net installer](https://cdimage.debian.org/cdimage/archive/8.10.0/amd64/iso-cd/debian-8.10.0-amd64-netinst.iso) (a more recent minor version should also work, see also [Debian Network installation](https://www.debian.org/CD/netinst/)).
 This DVD image can be [validated](https://www.debian.org/CD/verify) using a SHA256 hashing tool, for example on
 Unixy OSes by entering the following in a terminal:
 
-    echo "fd11d34f8abf1663a33cc10a9ed998160866ef94072d442159bcfa1438be70d4  debian-8.9.0-amd64-netinst.iso" | sha256sum -c
+    echo "896cc42998edf65f1db4eba83581941fb2a584f2214976432b841af96b17ccda  debian-8.10.0-amd64-netinst.iso" | sha256sum -c
     # (must return OK)
 
 Replace `sha256sum` with `shasum` on OSX.


### PR DESCRIPTION
The link to Debian 8.5.0 netinst is no longer valid and I couldn't find a reliable URL for this version.

Bump version to Debian 8.10.0 and update to correct URL.

I have tested all builds on 8.10.0 without noticeable issue, but welcome others to verify.