### PR TITLE
gitian: more specific default instructions

### DIFF
--- a/gitian-building/gitian-building-mac-os-sdk.md
+++ b/gitian-building/gitian-building-mac-os-sdk.md
@@ -1,0 +1,55 @@
+Gitian building Mac OS SDK
+==========================
+
+On the host machine, register for a free Apple [developer account](https://developer.apple.com/register/), then download the SDK [here](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_7.3.1/Xcode_7.3.1.dmg).
+
+MacOS host
+--------
+
+Using Mac OS X, you can mount the dmg, and then extract the SDK with:
+```
+  $ hdiutil attach Xcode_7.3.1.dmg
+  $ tar -C /Volumes/Xcode/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/ -czf MacOSX10.11.sdk.tar.gz MacOSX10.11.sdk
+```
+
+Clean up the files you don't need:
+
+```sh
+diskutil unmount /Volumes/Xcode
+rm MacOSX10.11.sdk.tar.gz Xcode_7.3.1.dmg
+```
+
+Non-MacOS host:
+--------
+
+Alternatively, you can use 7zip and SleuthKit to extract the files one by one.
+The script [extract-osx-sdk.sh](https://github.com/bitcoin/bitcoin/blob/master/contrib/macdeploy/extract-osx-sdk.sh) automates this. First ensure
+the dmg file is in the current directory, and then run the script.
+
+You may wish to delete the intermediate 5.hfs file and MacOSX10.11.sdk (the directory) when
+you've confirmed the extraction succeeded.
+
+```bash
+apt-get install p7zip-full sleuthkit
+contrib/macdeploy/extract-osx-sdk.sh
+rm -rf 5.hfs MacOSX10.11.sdk
+```
+
+Copy SDK to Gitian VM:
+----------------------
+Copy it to the Gitian VM, e.g.:
+
+```bash
+scp MacOSX10.11.sdk.tar.gz gitian:
+```
+
+Login to the VM and:
+
+```bash
+mkdir gitian-builder/inputs
+mv MacOSX10.11.sdk.tar.gz gitian-builder/inputs
+```
+
+Troubleshooting
+---------------
+See [README_osx.md](https://github.com/bitcoin/bitcoin/blob/master/doc/README_osx.md) for troubleshooting tips.

--- a/gitian-building/gitian-building-manual.md
+++ b/gitian-building/gitian-building-manual.md
@@ -1,0 +1,118 @@
+Getting and building the inputs
+--------------------------------
+
+At this point you have two options, you can either use the automated script (found in [https://github.com/bitcoin/bitcoin/blob/master/contrib/gitian-build.sh](https://github.com/bitcoin/bitcoin/blob/master/contrib/gitian-build.sh), only works in Debian/Ubuntu) or you could manually do everything by following this guide.
+If you are using the automated script, then run it with the `--setup` command. Afterwards, run it with the `--build` command (example: `contrib/gitian-build.sh -b signer 0.15.0`). Otherwise ignore this.
+
+Follow the instructions in [https://github.com/bitcoin/bitcoin/blob/master/doc/release-process.md](https://github.com/bitcoin/bitcoin/blob/master/doc/release-process.md#fetch-and-create-inputs-first-time-or-when-dependency-versions-change)
+in the bitcoin repository under 'Fetch and create inputs' to install sources which require
+manual intervention. Also optionally follow the next step: 'Seed the Gitian sources cache
+and offline git repositories' which will fetch the remaining files required for building
+offline.
+
+Building Bitcoin Core
+----------------
+
+To build Bitcoin Core (for Linux, OS X and Windows) just follow the steps under 'perform
+Gitian builds' in [https://github.com/bitcoin/bitcoin/blob/master/doc/release-process.md](https://github.com/bitcoin/bitcoin/blob/master/doc/release-process.md#setup-and-perform-gitian-builds) in the bitcoin repository.
+
+This may take some time as it will build all the dependencies needed for each descriptor.
+These dependencies will be cached after a successful build to avoid rebuilding them when possible.
+
+At any time you can check the package installation and build progress with
+
+```bash
+tail -f var/install.log
+tail -f var/build.log
+```
+
+Output from `gbuild` will look something like
+
+    Initialized empty Git repository in /home/gitianuser/gitian-builder/inputs/bitcoin/.git/
+    remote: Counting objects: 57959, done.
+    remote: Total 57959 (delta 0), reused 0 (delta 0), pack-reused 57958
+    Receiving objects: 100% (57959/57959), 53.76 MiB | 484.00 KiB/s, done.
+    Resolving deltas: 100% (41590/41590), done.
+    From https://github.com/bitcoin/bitcoin
+    ... (new tags, new branch etc)
+    --- Building for trusty amd64 ---
+    Stopping target if it is up
+    Making a new image copy
+    stdin: is not a tty
+    Starting target
+    Checking if target is up
+    Preparing build environment
+    Updating apt-get repository (log in var/install.log)
+    Installing additional packages (log in var/install.log)
+    Grabbing package manifest
+    stdin: is not a tty
+    Creating build script (var/build-script)
+    lxc-start: Connection refused - inotify event with no name (mask 32768)
+    Running build script (log in var/build.log)
+
+Building an alternative repository
+-----------------------------------
+
+If you want to do a test build of a pull on GitHub it can be useful to point
+the Gitian builder at an alternative repository, using the same descriptors
+and inputs.
+
+For example:
+```bash
+URL=https://github.com/laanwj/bitcoin.git
+COMMIT=2014_03_windows_unicode_path
+./bin/gbuild --commit bitcoin=${COMMIT} --url bitcoin=${URL} ../bitcoin/contrib/gitian-descriptors/gitian-linux.yml
+./bin/gbuild --commit bitcoin=${COMMIT} --url bitcoin=${URL} ../bitcoin/contrib/gitian-descriptors/gitian-win.yml
+./bin/gbuild --commit bitcoin=${COMMIT} --url bitcoin=${URL} ../bitcoin/contrib/gitian-descriptors/gitian-osx.yml
+```
+
+Building fully offline
+-----------------------
+
+For building fully offline including attaching signatures to unsigned builds, the detached-sigs repository
+and the bitcoin git repository with the desired tag must both be available locally, and then gbuild must be
+told where to find them. It also requires an apt-cacher-ng which is fully-populated but set to offline mode, or
+manually disabling gitian-builder's use of apt-get to update the VM build environment.
+
+To configure apt-cacher-ng as an offline cacher, you will need to first populate its cache with the relevant
+files. You must additionally patch target-bin/bootstrap-fixup to set its apt sources to something other than
+plain archive.ubuntu.com: us.archive.ubuntu.com works.
+
+So, if you use LXC:
+
+```bash
+export PATH="$PATH":/path/to/gitian-builder/libexec
+export USE_LXC=1
+cd /path/to/gitian-builder
+./libexec/make-clean-vm --suite trusty --arch amd64
+
+LXC_ARCH=amd64 LXC_SUITE=trusty on-target -u root apt-get update
+LXC_ARCH=amd64 LXC_SUITE=trusty on-target -u root \
+  -e DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends -y install \
+  $( sed -ne '/^packages:/,/[^-] .*/ {/^- .*/{s/"//g;s/- //;p}}' ../bitcoin/contrib/gitian-descriptors/*|sort|uniq )
+LXC_ARCH=amd64 LXC_SUITE=trusty on-target -u root apt-get -q -y purge grub
+LXC_ARCH=amd64 LXC_SUITE=trusty on-target -u root -e DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade
+```
+
+And then set offline mode for apt-cacher-ng:
+
+```
+/etc/apt-cacher-ng/acng.conf
+[...]
+Offlinemode: 1
+[...]
+
+service apt-cacher-ng restart
+```
+
+Then when building, override the remote URLs that gbuild would otherwise pull from the Gitian descriptors::
+```bash
+
+cd /some/root/path/
+git clone https://github.com/bitcoin-core/bitcoin-detached-sigs.git
+
+BTCPATH=/some/root/path/bitcoin
+SIGPATH=/some/root/path/bitcoin-detached-sigs
+
+./bin/gbuild --url bitcoin=${BTCPATH},signature=${SIGPATH} ../bitcoin/contrib/gitian-descriptors/gitian-win-signer.yml
+```


### PR DESCRIPTION
Fixes #9, #10, #11, #13 and #18

A bit more opinionated on what the default approach is, which should make this easier for first time gitian builders.

One thing I'm not yet happy about is how to move the assert files to the users real machine and then sign them. I have a half baked [script](https://gist.github.com/Sjors/ea4578dba596767c5e104ee4aaab09ce) for that, and I remember someone else is working on using a git remote for it. The instructions in this PR just tell the user to do it manually.

