### PR TITLE
Update external signing part

### DIFF
--- a/gitian-building.md
+++ b/gitian-building.md
@@ -181,10 +181,12 @@ When you execute `gsign` you will get an error from GPG, which can be ignored. C
 in `gitian.sigs` to your signing machine and do
 
 ```bash
-    gpg --detach-sign ${VERSION}-linux/${SIGNER}/bitcoin-linux-build.assert
-    gpg --detach-sign ${VERSION}-win/${SIGNER}/bitcoin-win-build.assert
-    gpg --detach-sign ${VERSION}-osx-unsigned/${SIGNER}/bitcoin-osx-build.assert
+    gpg --detach-sign ${VERSION}-linux/${SIGNER}/bitcoin-linux-*-build.assert
+    gpg --detach-sign ${VERSION}-win-unsigned/${SIGNER}/bitcoin-win-*-build.assert
+    gpg --detach-sign ${VERSION}-osx-unsigned/${SIGNER}/bitcoin-osx-*-build.assert
 ```
+
+You may have other .assert files as well (e.g. `signed` ones), in which case you should sign them too. You can see all of them by doing `ls ${VERSION}-*/${SIGNER}`.
 
 This will create the `.sig` files that can be committed together with the `.assert` files to assert your
 Gitian build.


### PR DESCRIPTION
The `.assert` files now include the version without minor (e.g. `0.16`), hence use of wildcard instead of `${VERSION}`.

Was also missing some versions (signed osx, and win needed a signed and unsigned version).