### PR TITLE
vmbuilder: Switch to the community version

### DIFF
--- a/gitian-building/gitian-building-setup-gitian-debian.md
+++ b/gitian-building/gitian-building-setup-gitian-debian.md
@@ -55,11 +55,8 @@ The rest of the steps in this guide will be performed as that user.
 There is no `python-vm-builder` package in Debian, so we need to install it from source ourselves,
 
 ```bash
-wget http://archive.ubuntu.com/ubuntu/pool/universe/v/vm-builder/vm-builder_0.12.4+bzr494.orig.tar.gz
-echo "76cbf8c52c391160b2641e7120dbade5afded713afaa6032f733a261f13e6a8e  vm-builder_0.12.4+bzr494.orig.tar.gz" | sha256sum -c
-# (verification -- must return OK)
-tar -zxvf vm-builder_0.12.4+bzr494.orig.tar.gz
-cd vm-builder-0.12.4+bzr494
+git clone https://github.com/newroco/vmbuilder.git
+cd vmbuilder
 sudo python setup.py install
 cd ..
 ```

--- a/gitian-building/gitian-building-setup-gitian-fedora.md
+++ b/gitian-building/gitian-building-setup-gitian-fedora.md
@@ -60,11 +60,8 @@ The rest of the steps in this guide will be performed as that user.
 There is no `python-vm-builder` package in Fedora, so we need to install it from source ourselves,
 
 ```bash
-wget http://archive.ubuntu.com/ubuntu/pool/universe/v/vm-builder/vm-builder_0.12.4+bzr494.orig.tar.gz
-echo "76cbf8c52c391160b2641e7120dbade5afded713afaa6032f733a261f13e6a8e  vm-builder_0.12.4+bzr494.orig.tar.gz" | sha256sum -c
-# (verification -- must return OK)
-tar -zxvf vm-builder_0.12.4+bzr494.orig.tar.gz
-cd vm-builder-0.12.4+bzr494
+git clone https://github.com/newroco/vmbuilder.git
+cd vmbuilder
 sudo python setup.py install
 cd ..
 ```


### PR DESCRIPTION
python-vm-builder seems generally outdated and unmaintained, but the for at https://github.com/newroco/vmbuilder seems to receive some maintainance by the community.

Parallel to https://github.com/devrandom/gitian-builder/pull/154