### PR TITLE
fedora: Use docker instead of lxc

### DIFF
--- a/gitian-building/gitian-building-create-vm-fedora.md
+++ b/gitian-building/gitian-building-create-vm-fedora.md
@@ -60,11 +60,11 @@ After creating the VM, we need to configure it.
 
 - Click `Ok` twice to save.
 
-Get the [Fedora Netinstall Image](https://download.fedoraproject.org/pub/fedora/linux/releases/27/Workstation/x86_64/iso/Fedora-Workstation-netinst-x86_64-27-1.6.iso) (other resonably recent release should work as well, see [Fedora Workstation Download page](https://getfedora.org/en/workstation/download/)).
+Get the [Fedora Netinstall Image](https://download.fedoraproject.org/pub/fedora/linux/releases/29/Workstation/x86_64/iso/Fedora-Workstation-netinst-x86_64-29-1.2.iso) (other resonably recent release should work as well, see [Fedora Workstation Download page](https://getfedora.org/en/workstation/download/)).
 This DVD image can be [validated](https://getfedora.org/verify) using a SHA256 hashing tool, for example on
 Unixy OSes by entering the following in a terminal:
 
-    echo "18ef4a6f9f470b40bd0cdf21e6c8f5c43c28e3a2200dcc8578ec9da25a6b376b  Fedora-Workstation-netinst-x86_64-27-1.6.iso" | sha256sum -c
+    echo "6554404b66d38b89693232966d9290ed62156e32d1edde4074b1d25c97a7b10e  Fedora-Workstation-netinst-x86_64-29-1.2.iso" | sha256sum -c
     # (must return OK)
 
 Replace `sha256sum` with `shasum` on OSX.

--- a/gitian-building/gitian-building-setup-gitian-fedora.md
+++ b/gitian-building/gitian-building-setup-gitian-fedora.md
@@ -15,34 +15,20 @@ We assume that a user `gitianuser` was previously created and added to the `whee
 First we need to set up dependencies. Type/paste the following in the terminal:
 
 ```bash
-sudo dnf install git python ruby apt-cacher-ng qemu dpkg debootstrap python-cheetah gnupg tar rsync wget curl lxc libvirt
+sudo dnf install git ruby gnupg docker tar rsync wget curl
 ```
 
-Then set up LXC and the rest with the following, which is a complex jumble of settings and workarounds:
+Then set up docker and the rest with the following, which is a complex jumble of settings and workarounds:
 
 ```bash
 sudo -s
-# Enable the apt-cacher-ng service
-systemctl enable apt-cacher-ng.service
-# the version of lxc-start in Fedora needs to run as root, so make sure
+systemctl enable docker.service
+# the version of docker in Fedora needs to run as root, so make sure
 # that the build script can execute it without providing a password
-echo "%wheel ALL=NOPASSWD: /usr/bin/lxc-start" > /etc/sudoers.d/gitian-lxc
-echo "%wheel ALL=NOPASSWD: /usr/bin/lxc-execute" >> /etc/sudoers.d/gitian-lxc
-# make /etc/rc.d/rc.local script that sets up bridge between guest and host
-echo '#!/bin/sh -e' > /etc/rc.d/rc.local
-echo 'brctl addbr br0' >> /etc/rc.d/rc.local
-echo 'ip addr add 10.0.3.1/24 broadcast 10.0.3.255 dev br0' >> /etc/rc.d/rc.local
-echo 'ip link set br0 up' >> /etc/rc.d/rc.local
-echo 'firewall-cmd --zone=trusted --add-interface=br0' >> /etc/rc.d/rc.local
-echo 'exit 0' >> /etc/rc.d/rc.local
-# mark executable so that the rc.local-service unit gets pulled automatically
-# into multi-user.target
-chmod +x /etc/rc.d/rc.local
-# make sure that USE_LXC is always set when logging in as gitianuser,
-# and configure LXC IP addresses
-echo 'export USE_LXC=1' >> /home/gitianuser/.bash_profile
-echo 'export GITIAN_HOST_IP=10.0.3.1' >> /home/gitianuser/.bash_profile
-echo 'export LXC_GUEST_IP=10.0.3.5' >> /home/gitianuser/.bash_profile
+# https://docs.docker.com/install/linux/linux-postinstall/
+groupadd docker
+usermod -aG docker gitianuser
+echo 'export USE_DOCKER=1' >> /home/gitianuser/.bash_profile
 reboot
 ```
 
@@ -56,20 +42,6 @@ Installing Gitian
 
 Login as the user `gitianuser` that was created during installation.
 The rest of the steps in this guide will be performed as that user.
-
-There is no `python-vm-builder` package in Fedora, so we need to install it from source ourselves,
-
-```bash
-wget http://archive.ubuntu.com/ubuntu/pool/universe/v/vm-builder/vm-builder_0.12.4+bzr494.orig.tar.gz
-echo "76cbf8c52c391160b2641e7120dbade5afded713afaa6032f733a261f13e6a8e  vm-builder_0.12.4+bzr494.orig.tar.gz" | sha256sum -c
-# (verification -- must return OK)
-tar -zxvf vm-builder_0.12.4+bzr494.orig.tar.gz
-cd vm-builder-0.12.4+bzr494
-sudo python setup.py install
-cd ..
-```
-
-**Note**: When sudo asks for a password, enter the password for the user `gitianuser` not for `root`.
 
 Clone the git repositories for bitcoin and Gitian.
 
@@ -94,11 +66,8 @@ Execute the following as user `gitianuser`:
 
 ```bash
 cd gitian-builder
-git checkout faa2dc2c2cc560bc0219db870490d88404f71370 # This version seems to work better than master
-bin/make-base-vm --lxc --arch amd64 --suite bionic # For releases after and including 0.17.0
-bin/make-base-vm --lxc --arch amd64 --suite trusty # For releases before 0.17.0
+bin/make-base-vm --docker --arch amd64 --suite bionic # For releases after and including 0.17.0
+bin/make-base-vm --docker --arch amd64 --suite trusty # For releases before 0.17.0
 ```
-
-There will be a lot of warnings printed during the build of the image. These can be ignored.
 
 **Note**: When sudo asks for a password, enter the password for the user `gitianuser` not for `root`.


### PR DESCRIPTION
Docker requires less dependencies to be installed and thus is hopefully less likely to break. Note that I also skipped the `apt-cacher-ng` dependency since it didn't appear to work for docker.

Do this first for fedora and potentially switch debian to using docker as well.