### PR TITLE
Mark created /etc/rc.local executable

### DIFF
--- a/gitian-building/gitian-building-setup-gitian-debian.md
+++ b/gitian-building/gitian-building-setup-gitian-debian.md
@@ -33,6 +33,7 @@ echo 'ip addr add 10.0.3.2/24 broadcast 10.0.3.255 dev br0' >> /etc/rc.local
 echo 'ip link set br0 up' >> /etc/rc.local
 echo 'firewall-cmd --zone=trusted --add-interface=br0' >> /etc/rc.local
 echo 'exit 0' >> /etc/rc.local
+chmod +x /etc/rc.local
 # make sure that USE_LXC is always set when logging in as gitianuser,
 # and configure LXC IP addresses
 echo 'export USE_LXC=1' >> /home/gitianuser/.profile


### PR DESCRIPTION
On Debian 9 the `/etc/rc.local` file has been deprecated. So the newly created one should be executable.

~`USE_LXC` environment variable is managed by the [`gitian-build.py`](https://github.com/bitcoin/bitcoin/blob/master/contrib/gitian-build.py) script.
Global export of USE_LXC breaks [`make-clean-vm`](https://github.com/devrandom/gitian-builder/blob/5dca44398924140619bb6ef63736ab31b76ba743/libexec/make-clean-vm#L8) logic of the `gitian-builder` when using Docker.~