### PR TITLE
docs: remove unsafe VDI size

### DIFF
--- a/gitian-building/gitian-building-create-vm-debian.md
+++ b/gitian-building/gitian-building-create-vm-debian.md
@@ -32,7 +32,7 @@ In the VirtualBox GUI click "New" and choose the following parameters in the wiz
 
 ![](figs/create_vm_file_location_size.png)
 
-- File location and size: at least 40GB; as low as 20GB *may* be possible, but better to err on the safe side
+- File location and size: at least 40GB
 - Click `Create`
 
 After creating the VM, we need to configure it.

--- a/gitian-building/gitian-building-create-vm-fedora.md
+++ b/gitian-building/gitian-building-create-vm-fedora.md
@@ -32,7 +32,7 @@ In the VirtualBox GUI click "New" and choose the following parameters in the wiz
 
 ![](figs/create_vm_file_location_size.png)
 
-- File location and size: at least 40GB; as low as 20GB *may* be possible, but better to err on the safe side
+- File location and size: at least 40GB
 - Click `Create`
 
 After creating the VM, we need to configure it.


### PR DESCRIPTION
On Debian after building (using Docker, w/o macOS) VDI is 34GB:
```
~/VirtualBox VMs/debian-9.5.0$ ls -l -h
total 34G
-rw------- 1 hebasto hebasto 3,0K Aug 19 09:57 debian-9.5.0.vbox
-rw------- 1 hebasto hebasto 3,0K Aug 18 20:31 debian-9.5.0.vbox-prev
-rw------- 1 hebasto hebasto  34G Aug 19 09:57 debian-9.5.0.vdi
drwx------ 2 hebasto hebasto 4,0K Aug 18 20:34 Logs
```