### PR TITLE
gitian: fix link in gitian-building-mac-os-sdk.md

### DIFF
--- a/gitian-building/gitian-building-mac-os-sdk.md
+++ b/gitian-building/gitian-building-mac-os-sdk.md
@@ -53,4 +53,4 @@ mv MacOSX10.11.sdk.tar.gz gitian-builder/inputs
 
 Troubleshooting
 ---------------
-See [README_osx.md](https://github.com/bitcoin/bitcoin/blob/master/doc/README_osx.md) for troubleshooting tips.
+See [build-osx.md](https://github.com/bitcoin/bitcoin/blob/master/doc/build-osx.md#deterministic-macos-dmg-notes) for troubleshooting tips.


### PR DESCRIPTION
Old link is dead.
This change links to useful information on macOS deteministic builds