### PR TITLE
gitian: Use the environment variable $NAME

### DIFF
--- a/gitian-building.md
+++ b/gitian-building.md
@@ -70,7 +70,7 @@ In order to sign gitian builds on your host machine, which has your PGP key, for
 
 ```
 export NAME=satoshi
-git clone git@github.com:bitcoin-core/gitian.sigs.git
+git clone git@github.com:$NAME/gitian.sigs.git
 git remote add $NAME git@github.com:$NAME/gitian.sigs.git
 ```
 


### PR DESCRIPTION
The user is unable to push to the bitcoin-core repository.
By inserting $NAME into the command - it stays consistent with the instructions.