### PR TITLE
Gitian: macOS instruction to check detached signature

### DIFF
--- a/gitian-building.md
+++ b/gitian-building.md
@@ -127,3 +127,18 @@ Gitian build.
  `./gitian-build.py --detach-sign -s $NAME $VERSION --nocommit`
 
 Make another pull request for these.
+
+Verify signed binaries
+----------------------
+
+If you have a macOS machine, you can verify that the unsigned binary was not modified
+during code signing, other than appending the signature. Fetch the signed dmg,
+as well as the detached signature (`gitian` is your gitian host):
+
+```bash
+VERSION=0.19.1rc2
+scp gitian:bitcoin-binaries/$VERSION/bitcoin-$VERSION-osx.dmg .
+scp -r gitian:gitian-builder/inputs/signature/osx detached-sig-osx
+hdiutil attach -mountpoint signed bitcoin-$VERSION-osx.dmg
+codesign -v --verbose signed/Bitcoin-Qt.app/Contents/MacOS/Bitcoin-Qt --detached detached-sig-osx/dist/Bitcoin-Qt.app/Contents/MacOS/Bitcoin-Qt.sign
+```


### PR DESCRIPTION
The macOS [Gitian build](https://github.com/bitcoin-core/docs/blob/master/gitian-building.md) process is split in two phases:

1. all builders create an unsigned binary
2. someone with a code signing certificate signs that binary and produces a detached signature

The detached signature is a separate file, which is glued on the unsigned binary. The scripts for this were introduced in https://github.com/bitcoin/bitcoin/pull/5363.

Currently the glue script [detached-sig-apply.sh](https://github.com/bitcoin/bitcoin/blob/master/contrib/macdeploy/detached-sig-apply.sh#L38-L54) doesn't verify the resulting signature; that only happens when you install and run the command.

Although probably not actually exploitable, in theory a compromised signer could make a binary like so: `(unsigned original + malware) + signature`. If for whatever reason execution could jump from the unsigned original to the malware, that would be bad.

Initially I wanted to make the glue script (run by all gitian signers) perform an additional check that the detached signature is valid and _only_ signs for `unsigned original`. Unfortunately `codesign` isn't part of [native_cctools](https://github.com/bitcoin/bitcoin/blob/master/depends/packages/native_cctools.mk) (only `codesign_allocate`).

So instead I wrote an instruction for macOS users, which fetches the signed binary and detached signature and verifies it.